### PR TITLE
Bug fix in StructDeclaration: added "name" field

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -1645,6 +1645,7 @@ StructDeclaration
   {
     return {
       type: "StructDeclaration",
+      name: id.name,
       body: body != null ? body.declarations : null,
       start: location().start.offset,
       end: location().end.offset


### PR DESCRIPTION
The StructDeclaration (line 1643) was missing the "name" field. This means the solidity-parser generated tree of a simple struct declaration would not display the struct's name (which is a very crucial property).

I've fixed this, and tested on my local system. Works good =)