### PR TITLE
Fix cli with file arguments

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,7 +8,7 @@ var result;
 if (argv.e) {
   result = SolidityParser.parse(argv.e || argv.expression);
 } else {
-  SolidityParser.parseFile(argv.f || argv.file || argv._[0]);
+  result = SolidityParser.parseFile(argv.f || argv.file || argv._[0]);
 }
 
 console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
`result` was not being assigned when the cli was called with file arguments.