### PR TITLE
Remove automatic semicolon insertion

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -532,13 +532,7 @@ __
 _
   = (WhiteSpace / MultiLineCommentNoLineTerminator)*
 
-/* Automatic Semicolon Insertion */
-
-EOS
-  = __ ";"
-  / _ SingleLineComment? LineTerminatorSequence
-  / _ &"}"
-  / __ EOF
+EOS = __ ";"
 
 EOF
   = !.

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -187,7 +187,7 @@ contract DualIndex {
   mapping(uint => mapping(uint => uint)) data;
   address public admin;
 
-  modifier restricted { if (msg.sender == admin) _ }
+  modifier restricted { if (msg.sender == admin) _; }
 
   function DualIndex() {
     admin = msg.sender;
@@ -233,7 +233,7 @@ contract FromSolparse is A, B, TestPrivate, TestInternal {
   function() {
     uint a = 6 ** 9;
     var (x) = 100;
-    uint y = 2 days
+    uint y = 2 days;
   }
 }
 


### PR DESCRIPTION
Now requires each statement to be terminated by a semicolon.