### PR TITLE
fix: Issue_38 allow varaibles to have left or right bracket

### DIFF
--- a/build/imports_parser.js
+++ b/build/imports_parser.js
@@ -3996,7 +3996,10 @@ function peg$parse(input, options) {
           if (s5 === peg$FAILED) {
             s5 = peg$parseBlockList();
             if (s5 === peg$FAILED) {
-              s5 = peg$parseNonClosingBracketCharacter();
+              s5 = peg$parseStringLiteral();
+              if (s5 === peg$FAILED) {
+                s5 = peg$parseNonClosingBracketCharacter();
+              }
             }
           }
           while (s5 !== peg$FAILED) {
@@ -4005,7 +4008,10 @@ function peg$parse(input, options) {
             if (s5 === peg$FAILED) {
               s5 = peg$parseBlockList();
               if (s5 === peg$FAILED) {
-                s5 = peg$parseNonClosingBracketCharacter();
+                s5 = peg$parseStringLiteral();
+                if (s5 === peg$FAILED) {
+                  s5 = peg$parseNonClosingBracketCharacter();
+                }
               }
             }
           }

--- a/imports.pegjs
+++ b/imports.pegjs
@@ -429,7 +429,7 @@ SourceElements
     }
 
 BlockList
-  = __ "{" __ ( Comment / BlockList / NonClosingBracketCharacter )* __ "}"
+  = __ "{" __ ( Comment / BlockList / StringLiteral / NonClosingBracketCharacter )* __ "}"
 
 NonClosingBracketCharacter
   = (!("}") SourceCharacter)

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -249,6 +249,11 @@ contract CommentedOutFunction {
   // }
 }
 
+library VarHasBrackets {
+	string constant specialRight = "}";
+	string storage specialLeft = "{";
+}
+
 library UsingExampleLibrary {
   function sum(uint[] storage self) returns (uint s) {
     for (uint i = 0; i < self.length; i++)


### PR DESCRIPTION
@tcoulter  @federicobond Resolves [issue 38](https://github.com/ConsenSys/solidity-parser/issues/38). This pull request is heavy handed.

imports.pegjs is identical to solidity.pegjs with the addition of `simplifyImports` to conform with the original output for truffle [profiler](https://github.com/ConsenSys/truffle/blob/master/lib/profiler.js#L134).

Adding the test to the current repo will result in failures. But once patch is applied, test pass. 