### PR TITLE
Draft fix for #26 

### DIFF
--- a/build/parser.js
+++ b/build/parser.js
@@ -552,17 +552,18 @@ function peg$parse(input, options) {
             end: location().end.offset
           }
         },
-      peg$c291 = function(type, isconstant, ispublic, isprivate, isinternal, isstorage, ismemory, id) {
+      peg$c291 = function(type, tokens, id) {
+          var descriptors = extractList(extractList(tokens, 1), 0);
           return {
             type: "DeclarativeExpression",
             name: id.name,
             literal: type,
-            is_constant: isconstant != null,
-            is_public: ispublic != null,
-            is_private: isprivate != null,
-            is_internal: isinternal != null,
-            is_storage: isstorage != null,
-            is_memory: ismemory != null,
+            is_constant: descriptors.includes('constant') || false,
+            is_public: descriptors.includes('public') || false,
+            is_private: descriptors.includes('private') || false,
+            is_internal: descriptors.includes('internal') || false,
+            is_storage: descriptors.includes('storage') || false,
+            is_memory: descriptors.includes('memory') || false,
             start: location().start.offset,
             end: location().end.offset
           }
@@ -7450,101 +7451,91 @@ function peg$parse(input, options) {
     return s0;
   }
 
+  function peg$parseDeclarativeExpressionDescriptor() {
+    var s0;
+
+    s0 = peg$parseConstantToken();
+    if (s0 === peg$FAILED) {
+      s0 = peg$parsePublicToken();
+      if (s0 === peg$FAILED) {
+        s0 = peg$parsePrivateToken();
+        if (s0 === peg$FAILED) {
+          s0 = peg$parseInternalToken();
+          if (s0 === peg$FAILED) {
+            s0 = peg$parseStorageToken();
+            if (s0 === peg$FAILED) {
+              s0 = peg$parseMemoryToken();
+            }
+          }
+        }
+      }
+    }
+
+    return s0;
+  }
+
   function peg$parseDeclarativeExpression() {
-    var s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15;
+    var s0, s1, s2, s3, s4, s5, s6, s7;
 
     s0 = peg$currPos;
     s1 = peg$parseType();
     if (s1 !== peg$FAILED) {
       s2 = peg$parse__();
       if (s2 !== peg$FAILED) {
-        s3 = peg$parseConstantToken();
-        if (s3 === peg$FAILED) {
-          s3 = null;
+        s3 = [];
+        s4 = peg$currPos;
+        s5 = peg$parse__();
+        if (s5 !== peg$FAILED) {
+          s6 = peg$parseDeclarativeExpressionDescriptor();
+          if (s6 !== peg$FAILED) {
+            s7 = peg$parse__();
+            if (s7 !== peg$FAILED) {
+              s5 = [s5, s6, s7];
+              s4 = s5;
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
+          }
+        } else {
+          peg$currPos = s4;
+          s4 = peg$FAILED;
+        }
+        while (s4 !== peg$FAILED) {
+          s3.push(s4);
+          s4 = peg$currPos;
+          s5 = peg$parse__();
+          if (s5 !== peg$FAILED) {
+            s6 = peg$parseDeclarativeExpressionDescriptor();
+            if (s6 !== peg$FAILED) {
+              s7 = peg$parse__();
+              if (s7 !== peg$FAILED) {
+                s5 = [s5, s6, s7];
+                s4 = s5;
+              } else {
+                peg$currPos = s4;
+                s4 = peg$FAILED;
+              }
+            } else {
+              peg$currPos = s4;
+              s4 = peg$FAILED;
+            }
+          } else {
+            peg$currPos = s4;
+            s4 = peg$FAILED;
+          }
         }
         if (s3 !== peg$FAILED) {
           s4 = peg$parse__();
           if (s4 !== peg$FAILED) {
-            s5 = peg$parsePublicToken();
-            if (s5 === peg$FAILED) {
-              s5 = null;
-            }
+            s5 = peg$parseIdentifier();
             if (s5 !== peg$FAILED) {
-              s6 = peg$parse__();
-              if (s6 !== peg$FAILED) {
-                s7 = peg$parsePrivateToken();
-                if (s7 === peg$FAILED) {
-                  s7 = null;
-                }
-                if (s7 !== peg$FAILED) {
-                  s8 = peg$parse__();
-                  if (s8 !== peg$FAILED) {
-                    s9 = peg$parseInternalToken();
-                    if (s9 === peg$FAILED) {
-                      s9 = null;
-                    }
-                    if (s9 !== peg$FAILED) {
-                      s10 = peg$parse__();
-                      if (s10 !== peg$FAILED) {
-                        s11 = peg$parseStorageToken();
-                        if (s11 === peg$FAILED) {
-                          s11 = null;
-                        }
-                        if (s11 !== peg$FAILED) {
-                          s12 = peg$parse__();
-                          if (s12 !== peg$FAILED) {
-                            s13 = peg$parseMemoryToken();
-                            if (s13 === peg$FAILED) {
-                              s13 = null;
-                            }
-                            if (s13 !== peg$FAILED) {
-                              s14 = peg$parse__();
-                              if (s14 !== peg$FAILED) {
-                                s15 = peg$parseIdentifier();
-                                if (s15 !== peg$FAILED) {
-                                  peg$savedPos = s0;
-                                  s1 = peg$c291(s1, s3, s5, s7, s9, s11, s13, s15);
-                                  s0 = s1;
-                                } else {
-                                  peg$currPos = s0;
-                                  s0 = peg$FAILED;
-                                }
-                              } else {
-                                peg$currPos = s0;
-                                s0 = peg$FAILED;
-                              }
-                            } else {
-                              peg$currPos = s0;
-                              s0 = peg$FAILED;
-                            }
-                          } else {
-                            peg$currPos = s0;
-                            s0 = peg$FAILED;
-                          }
-                        } else {
-                          peg$currPos = s0;
-                          s0 = peg$FAILED;
-                        }
-                      } else {
-                        peg$currPos = s0;
-                        s0 = peg$FAILED;
-                      }
-                    } else {
-                      peg$currPos = s0;
-                      s0 = peg$FAILED;
-                    }
-                  } else {
-                    peg$currPos = s0;
-                    s0 = peg$FAILED;
-                  }
-                } else {
-                  peg$currPos = s0;
-                  s0 = peg$FAILED;
-                }
-              } else {
-                peg$currPos = s0;
-                s0 = peg$FAILED;
-              }
+              peg$savedPos = s0;
+              s1 = peg$c291(s1, s3, s5);
+              s0 = s1;
             } else {
               peg$currPos = s0;
               s0 = peg$FAILED;

--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -716,19 +716,28 @@ Type
     }
   }
 
+DeclarativeExpressionDescriptor
+  = ConstantToken
+  / PublicToken
+  / PrivateToken
+  / InternalToken
+  / StorageToken
+  / MemoryToken
+
 DeclarativeExpression
-  = type:Type __ isconstant:ConstantToken? __ ispublic:PublicToken? __ isprivate:PrivateToken? __ isinternal:InternalToken? __ isstorage:StorageToken? __ ismemory:MemoryToken? __ id:Identifier
+  = type:Type __ tokens:( __ DeclarativeExpressionDescriptor __ )* __ id:Identifier
   {
+    var descriptors = extractList(extractList(tokens, 1), 0);
     return {
       type: "DeclarativeExpression",
       name: id.name,
       literal: type,
-      is_constant: isconstant != null,
-      is_public: ispublic != null,
-      is_private: isprivate != null,
-      is_internal: isinternal != null,
-      is_storage: isstorage != null,
-      is_memory: ismemory != null,
+      is_constant: descriptors.includes('constant') || false,
+      is_public: descriptors.includes('public') || false,
+      is_private: descriptors.includes('private') || false,
+      is_internal: descriptors.includes('internal') || false,
+      is_storage: descriptors.includes('storage') || false,
+      is_memory: descriptors.includes('memory') || false,
       start: location().start.offset,
       end: location().end.offset
     }

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -313,3 +313,11 @@ contract memoryArrays {
     uint[] memory b = new uint[](returnNumber(seven));
   }
 }
+
+contract declarativeExpressionDescriptors {
+  uint a = 0;
+  uint constant internal b = 0;
+  uint internal constant c = 0;
+  uint constant constant constant d = 0;
+  uint constant public private internal storage memory e = 0;
+}


### PR DESCRIPTION
This PR rewrites the declarative expression rule to allow descriptors like `constant` and `internal` to appear in any order. 

It
+ Creates a new rule for the set of descriptors
+ Replaces `DeclarativeExpression`'s optional descriptor series with greedy collection
+ Extracts the descriptors from collected array & sets the relevant expression values

Also adds example to `doc_examples` and has rebuild.