### PR TITLE
Rename is to baseContracts in ContractStatement node

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -1388,13 +1388,13 @@ DebuggerStatement
   = DebuggerToken EOS { return { type: "DebuggerStatement", start: location().start.offset, end: location().end.offset }; }
 
 ContractStatement
-  = ContractToken __ id:Identifier __ is:IsStatement? __
+  = ContractToken __ id:Identifier __ baseContracts:InheritanceSpecifier? __
     "{" __ body:SourceElements? __ "}"
   {
     return {
       type: "ContractStatement",
       name: id.name,
-      is: is != null ? is.names : [],
+      baseContracts: baseContracts != null ? baseContracts.names : [],
       body: body,
       start: location().start.offset,
       end: location().end.offset
@@ -1402,25 +1402,25 @@ ContractStatement
   }
 
 LibraryStatement
-  = LibraryToken __ id:Identifier __ is:IsStatement? __
+  = LibraryToken __ id:Identifier __ baseContracts:InheritanceSpecifier? __
     "{" __ body:SourceElements? __ "}"
   {
     return {
       type: "LibraryStatement",
       name: id.name,
-      is: is != null ? is.names : [],
+      baseContracts: baseContracts != null ? baseContracts.names : [],
       body: body,
       start: location().start.offset,
       end: location().end.offset
     }
   }
 
-IsStatement
-  = IsToken __ modifiers:CommaSeparatedModifierNameList
+InheritanceSpecifier
+  = IsToken __ names:CommaSeparatedModifierNameList
   {
     return {
-      type: "IsStatement",
-      names: modifiers,
+      type: "InheritanceSpecifier",
+      names: names,
       start: location().start.offset,
       end: location().end.offset
     }


### PR DESCRIPTION
Also rename `IsStatement` rule to `InheritanceSpecifier` and other internal name changes.