### PR TITLE
Change DeclarativeExpression's management of visibility and storage specifiers

### DIFF
--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -251,7 +251,7 @@ contract CommentedOutFunction {
 
 library VarHasBrackets {
 	string constant specialRight = "}";
-	string storage specialLeft = "{";
+	//string storage specialLeft = "{";
 }
 
 library UsingExampleLibrary {
@@ -311,5 +311,21 @@ contract memoryArrays {
   function alloc() {
     uint[] memory a = new uint[](7);
     uint[] memory b = new uint[](returnNumber(seven));
+  }
+}
+
+contract DeclarativeExpressions {
+  uint a;
+  uint b = 7;
+  uint public c;
+  uint constant public d;
+  uint public constant e;
+  uint private constant f = 7;
+  struct S { uint q;}
+
+  function ham(S storage s1, uint[] storage arr) internal {
+    S storage s2 = s1;
+    uint[] memory stor;
+    uint[] storage stor2 = arr;
   }
 }

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -317,6 +317,7 @@ contract memoryArrays {
 contract DeclarativeExpressions {
   uint a;
   uint b = 7;
+  uint b2=0;
   uint public c;
   uint constant public d;
   uint public constant e;
@@ -324,6 +325,8 @@ contract DeclarativeExpressions {
   struct S { uint q;}
 
   function ham(S storage s1, uint[] storage arr) internal {
+    uint x;
+    uint y = 7;
     S storage s2 = s1;
     uint[] memory stor;
     uint[] storage stor2 = arr;


### PR DESCRIPTION
This PR is based on @federicobond's review of PR #44. He suggested the parser should distinguish between StateVariable declarations (which may be constant and have an optional visibility specifier)  and local declarations which only have an optional storage specifier. The solution discussed in #44 involved moving constant and visibility handling to a new `StateVariableDeclaration` rule under `SourceElement` and leaving DeclarativeExpression for locals. 

The PR below takes a slightly different approach, in part because subsequent developments in #56. It keeps all specifier management in the DelcarativeExpression and adds a check at `SourceElement --> AssignmentExpression` which verifies that `AssignmentExpression`'s left node does not have a storage specifier. It also modifies the entry for `DeclarativeExpression` at `SourceElement` to return only the node, in preparation for whatever will be done for #56. 

Additionally, one line has been commented out in the existing `.sol` test-bed because solc doesn't seem to compile it. 
```javascript
library VarHasBrackets {
	string constant specialRight = "}";
	string storage specialLeft = "{"; // <-- Is this legal?
}
```

In sum: PR fixes #26. StateVariables can no longer be assigned a storage specifier and locals can no longer be designated `constant` or have visibility specifiers. 

A gist of the AST for the added test [can be found here](https://gist.github.com/cgewecke/d2bea9c00c3375845fd74d98b5879e61).

@federicobond I'm about to add you as a collaborator on my fork of solidty-parser so you are free to revise / simplify this PR as you wish. I'm also happy to update with any suggestions you have. Also happy to close if this is not the solution you're looking for. 😄 

Build not included. 
