### PR TITLE
Add VariableDeclarationTuple rule

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -984,6 +984,35 @@ VariableStatement
         end: location().end.offset
       };
     }
+    / VarToken __ tuple:VariableDeclarationTuple EOS {
+      return {
+        type:         "VariableDeclarationTuple",
+        declarations: tuple.declarations,
+        init: tuple.init,
+        start: location().start.offset,
+        end: location().end.offset
+      };
+    }
+
+VariableDeclarationTuple
+  = "(" head:VariableDeclarationNoInit tail:(__ "," __ VariableDeclarationNoInit)* ")" init:(__ Initialiser) {
+      return {
+        declarations: buildList(head, tail, 3),
+        init: extractOptional(init, 1)
+      }
+    }
+
+VariableDeclarationNoInit
+  = id:Identifier {
+      return {
+        type: "VariableDeclarator",
+        id: id.constructor === Array ? id [1] : id,
+        init: null,
+        start: location().start.offset,
+        end: location().end.offset
+      };
+    }
+
 
 VariableDeclarationList
   = head:VariableDeclaration tail:(__ "," __ VariableDeclaration)* {

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -332,3 +332,14 @@ contract DeclarativeExpressions {
     uint[] storage stor2 = arr;
   }
 }
+
+contract VariableDeclarationTuple {
+  function getMyTuple() returns (bool, bool){
+    return (true, false);
+  }
+  
+  function ham (){
+    var (x, y) = (10, 20);
+    var (a, b) = getMyTuple();
+  }
+}


### PR DESCRIPTION
This PR 
+ adds a rule to allow tuple formatted variable declarations like `var(x,y) = (10, 20);`.
+ adds examples of tuple use to `doc_examples.sol` 
+ restores the `VariableDeclarationNoInit` rule that was removed in #36. It looks like using `VariableDeclaration` to implement the tuple rule would allow `var(x = 5, y) = (10, 20)`? 
+ Resolves #9. (A sample AST for this proposal can be found there).

NB: The code in this PR was authored by @duaraghav8 as part of [solparse](https://github.com/duaraghav8/solparse). He has given permission to integrate his bug-fixes into this repo so that solidity parser efforts can be consolidated in one place.     
