### PR TITLE
Consume function braces at FunctionBody rule

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -1311,8 +1311,7 @@ EventDeclaration
   }
 
 ModifierDeclaration
-  = ModifierToken __ fnname:ModifierName __ names:ModifierNameList? __
-     __ body:FunctionBody __
+  = ModifierToken __ fnname:ModifierName __ names:ModifierNameList? __ body:FunctionBody
     {
       return {
         type: "ModifierDeclaration",

--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -1312,7 +1312,7 @@ EventDeclaration
 
 ModifierDeclaration
   = ModifierToken __ fnname:ModifierName __ names:ModifierNameList? __
-    "{" __ body:FunctionBody __ "}"
+     __ body:FunctionBody __
     {
       return {
         type: "ModifierDeclaration",
@@ -1326,20 +1326,33 @@ ModifierDeclaration
     }
 
 FunctionDeclaration
-  = FunctionToken __ fnname:FunctionName __ args:ModifierArgumentList? __
-    body:("{" __ FunctionBody __ "}")? (__ EOS)?  // Remove EmptyStatement if no body
+  = FunctionToken __ fnname:FunctionName __ args:ModifierArgumentList? __ body:FunctionBody
     {
       return {
         type: "FunctionDeclaration",
         name: fnname.name,
         params: fnname.params,
         modifiers: args,
-        body: body != null ? body[2] : null,
-        is_abstract: body == null,
+        body: body,
+        is_abstract: false,
         start: location().start.offset,
         end: location().end.offset
       };
     }
+  / FunctionToken __ fnname:FunctionName __ args:ModifierArgumentList? __ EOS
+    {
+      return {
+        type: "FunctionDeclaration",
+        name: fnname.name,
+        params: fnname.params,
+        modifiers: args,
+        body: null,
+        is_abstract: true,
+        start: location().start.offset,
+        end: location().end.offset
+      };
+    }
+    
 
 FunctionName
   = id:Identifier? __ params:("(" __ InformalParameterList? __ ")")
@@ -1420,7 +1433,7 @@ InformalParameterList
 
 
 FunctionBody
-  = body:Statements? {
+  = "{" __ body:Statements? __ "}" {
       return {
         type: "BlockStatement",
         body: optionalList(body),


### PR DESCRIPTION
This PR
+ Relocates the opening and closing braces for function and modifier declarations to the function body rule, per the official grammar. 
+ Resolves #58 (See issue for further discussion)

A gist showing the current and proposed ASTs side by side can be found [here](https://gist.github.com/cgewecke/9faa561c644eaa9d2d455c1b1bb96198). They differ in where they mark the start / end positions of the declarations and block statements.  

NB: The code in this PR was authored by @duaraghav8 as part of [solparse](https://github.com/duaraghav8/solparse). He has given permission to integrate his bug-fixes into this repo so that solidity parser efforts can be consolidated in one place.    
