### PR TITLE
Allow spaces before array index at Type rule.

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -664,13 +664,13 @@ LeftHandSideExpression
   / NewExpression
 
 Type
-  = literal:(Mapping / Identifier) members:("." Identifier)* parts:("[" __ (Expression)? __ "]")*
+  = literal:(Mapping / Identifier) members:("." Identifier)* parts:(__"[" __ (Expression)? __ "]")*
   {
     return {
       type: "Type",
       literal: literal.type == "Identifier" ? literal.name : literal,
       members: optionalList(members).map(function(m) {return m[1].name;}),
-      array_parts: optionalList(parts).map(function(p) {return p[2] != null ? p[2].value : null}),
+      array_parts: optionalList(parts).map(function(p) {return p[3] != null ? p[3].value : null}),
       start: location().start.offset,
       end: location().end.offset
     }

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -332,3 +332,8 @@ contract DeclarativeExpressions {
     uint[] storage stor2 = arr;
   }
 }
+
+contract TypeIndexSpacing {
+  uint [ 7 ] x;
+  uint  []  y;
+}


### PR DESCRIPTION
Solidity-parser currently throws an error if there are intervening spaces between a Type name and its array brackets.  Ex: 
```javascript
uint[] x;  // <-- Fine
uint [] x; // <-- Legal but errors 
```

This PR 
+ Rewrites the Type rule to allow spaces before its array parts.
+ Adds some examples of liberally spaced array declarations to `doc_examples.sol`

NB: The code in this PR was authored by @duaraghav8 as part of solparse. He has given permission to integrate his bug-fixes into this repo so that solidity parser efforts can be consolidated in one place.

