### PR TITLE
Allow numeric and string literals for AssemblyLocalBinding rule

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -1522,7 +1522,7 @@ InlineAssemblyBlock
   }
 
 AssemblyItem
-  = FunctionalAssemblyExpression
+  = FunctionalAssemblyInstruction
   / InlineAssemblyBlock
   / AssemblyLocalBinding
   / AssemblyAssignment
@@ -1531,8 +1531,17 @@ AssemblyItem
   / HexStringLiteral
   / Identifier
 
+AssemblyExpression
+  = FunctionalAssemblyInstruction
+  / ElementaryAssemblyOperation
+
+ElementaryAssemblyOperation
+  = NumericLiteral
+  / StringLiteral
+  / Identifier
+
 AssemblyLocalBinding
-  = 'let' __ name:Identifier __ ':=' __ expression:FunctionalAssemblyExpression {
+  = 'let' __ name:Identifier __ ':=' __ expression:AssemblyExpression {
     return {
       type: "AssemblyLocalBinding",
       name: name,
@@ -1543,7 +1552,7 @@ AssemblyLocalBinding
   }
 
 AssemblyAssignment
-  = name:Identifier __ ':=' __ expression:FunctionalAssemblyExpression {
+  = name:Identifier __ ':=' __ expression:FunctionalAssemblyInstruction {
     return {
       type: "AssemblyAssignment",
       name: name,
@@ -1561,10 +1570,10 @@ AssemblyAssignment
     }
   }
 
-FunctionalAssemblyExpression
+FunctionalAssemblyInstruction
   = name:Identifier __ '(' __ head:AssemblyItem? __ tail:( ',' __ AssemblyItem )* __ ')' {
     return {
-      type: "FunctionalAssemblyExpression",
+      type: "FunctionalAssemblyInstruction",
       name: name,
       arguments: buildList(head, tail, 2),
       start: location().start.offset,

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -297,6 +297,17 @@ library GetCode {
     }
 }
 
+contract assemblyLocalBinding {
+  function test(){
+    assembly {
+      let v := 1
+      let x := 0x00
+      let y := x
+      let z := "hello" 
+    }
+  }
+}
+
 contract usesConst {
   uint const = 0;
 }


### PR DESCRIPTION
It looks like the published Solidity grammar might have an error in its AssemblyLocalDefinition rule
(`AssemblyLocalBinding` in solidity-parser). Solc compiles these assembly statements without complaint:
```
let v := 1
let x := 0x00
let z := "hello"
```
but the official grammar doesn't specify that numeric and string literals are allowed. 

Solc rejects this hex string literal: 
```
let y := hex "aaaaa"
```
Is there anything else allowed on the right hand side here?

Have modified the `AssemblyLocalBinding` rule to parse numbers and strings and included examples for the `doc_examples` test. Have not included a build. 

