### PR TITLE
Allow omitted elements in destructuring tuple assignments

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -524,6 +524,9 @@ EOS = __ ";"
 EOF
   = !.
 
+Comma
+  = __ "," __
+
 /* ----- A.2 Number Conversions ----- */
 
 /* Irrelevant. */
@@ -997,9 +1000,9 @@ VariableStatement
     }
 
 VariableDeclarationTuple
-  = "(" head:VariableDeclarationNoInit tail:(__ "," __ VariableDeclarationNoInit)* ")" init:(__ Initialiser) {
+  = "(" Comma* head:VariableDeclarationNoInit tail:(Comma+ VariableDeclarationNoInit)* Comma* ")" init:(__ Initialiser) {
       return {
-        declarations: buildList(head, tail, 3),
+        declarations: buildList(head, tail, 1),
         init: extractOptional(init, 1)
       }
     }

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -356,6 +356,9 @@ contract VariableDeclarationTuple {
   function ham (){
     var (x, y) = (10, 20);
     var (a, b) = getMyTuple();
+    var (,c) = (10, 20);
+    var (d,,) = (10, 20, 30);
+    var (,e,,f,) = (10, 20, 30, 40, 50);
   }
 }
 


### PR DESCRIPTION
+ Rewrites`VariableDeclarationTuple` rule to parse de-structuring assignments correctly:
```
var (,c) = (10, 20);
var (d,,) = (10, 20, 30);
```
+ Adds some examples to the tests
+ Resolves #69

[Gist of AST for this change](https://gist.github.com/cgewecke/d4a9d3bcd443d8dad5493f94efd10eec)
