### PR TITLE
Parse function calls that use a name-value list

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -657,10 +657,29 @@ Arguments
   = "(" __ args:(ArgumentList __)? ")" {
       return optionalList(extractOptional(args, 0));
     }
+  / "(" __ "{" __ args:(NameValueList __ )? "}" __ ")" {
+      return optionalList(extractOptional(args, 0));
+    }
 
 ArgumentList
   = head:AssignmentExpression tail:(__ "," __ AssignmentExpression)* {
       return buildList(head, tail, 3);
+    }
+
+NameValueList
+  = head:NameValueAssignment tail:(__ "," __ NameValueAssignment)* {
+      return buildList(head, tail, 3);
+    }
+
+NameValueAssignment
+  = id:Identifier __ ":" __ value:AssignmentExpression __ {
+      return {
+        type: "NameValueAssignment",
+        name: id.name,
+        value: value,
+        start: location().start.offset,
+        end: location().end.offset
+      };
     }
 
 LeftHandSideExpression

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -366,3 +366,22 @@ contract TypeIndexSpacing {
   uint [ 7 ] x;
   uint  []  y;
 }
+
+contract Ballot {
+
+    struct Voter {
+        uint weight;
+        bool voted;
+    }
+
+    function abstain() returns (bool) {
+      return false;
+    }
+
+    Voter you = Voter(1, true);
+
+    Voter me = Voter({
+        weight: 2,
+        voted: abstain()
+    });
+}


### PR DESCRIPTION
This PR addresses #71, where SP throws an error when instantiating a `struct` as below:
```javascript
Voter me = Voter({
        weight: 2, 
        voted: false
    });
```

The relevant part of the Solidity grammar looks like this:
```
ExpressionList = Expression ( ',' Expression )*
NameValueList = Identifier ':' Expression ( ',' Identifier ':' Expression )*
FunctionCall =  [ . . .etc*. . .]  '(' FunctionCallArguments ')'
FunctionCallArguments = '{' NameValueList? '}' | ExpressionList?
```

+ Added some tests to `doc_examples.sol`
+ [Gist of the AST for this change here](https://gist.github.com/cgewecke/1d18ca0befdbc9702e6f62fc6908baf5)
