### PR TITLE
Allow trailing comma in name-value lists

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -660,6 +660,9 @@ Arguments
   / "(" __ "{" __ args:(NameValueList __ )? "}" __ ")" {
       return optionalList(extractOptional(args, 0));
     }
+  / "(" __ "{" __ args:NameValueList __  "," __ "}" __ ")" {
+      return args;
+    }
 
 ArgumentList
   = head:AssignmentExpression tail:(__ "," __ AssignmentExpression)* {

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -384,4 +384,9 @@ contract Ballot {
         weight: 2,
         voted: abstain()
     });
+
+    Voter airbnb = Voter({
+      weight: 2,
+      voted: true,
+    });
 }


### PR DESCRIPTION
Fix for additional issue in #71 / #72  . . . solc [allows a trailing comma](https://github.com/ethereum/solidity/blob/develop/libsolidity/parsing/Parser.cpp#L1323) in name-value lists (as long as there's at least one list item.)

+ Added a trailing comma case to the tests
+ [Gist of AST with this change](https://gist.github.com/cgewecke/6cec3b3d2356c5533fa6f696a809ffa9) (No differences)
