### PR TITLE
Consume whitespace in VariableDeclarationTuple correctly

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -1019,7 +1019,7 @@ VariableStatement
     }
 
 VariableDeclarationTuple
-  = "(" Comma* head:VariableDeclarationNoInit tail:(Comma+ VariableDeclarationNoInit)* Comma* ")" init:(__ Initialiser) {
+  = "("Comma* __ head:VariableDeclarationNoInit tail:(Comma+ VariableDeclarationNoInit)* __ Comma* ")" init:(__ Initialiser) {
       return {
         declarations: buildList(head, tail, 1),
         init: extractOptional(init, 1)

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -359,6 +359,11 @@ contract VariableDeclarationTuple {
     var (,c) = (10, 20);
     var (d,,) = (10, 20, 30);
     var (,e,,f,) = (10, 20, 30, 40, 50);
+
+    var (
+      num1, num2,
+      num3, ,num5
+    ) = (10, 20, 30, 40, 50);
   }
 }
 


### PR DESCRIPTION
Fix for #74. Whitespace is not being consumed at the beginning/end of the rule if there are no commas. 