### PR TITLE
Allow "return" keyword to be used as assembly opcode

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -1610,8 +1610,18 @@ AssemblyAssignment
     }
   }
 
+ReturnOpCode 
+  = 'return' {
+    return {
+      type: "Identifier",
+      name: "return",
+      start: location().start.offset,
+      end: location().end.offset
+    }
+  }
+
 FunctionalAssemblyInstruction
-  = name:Identifier __ '(' __ head:AssemblyItem? __ tail:( ',' __ AssemblyItem )* __ ')' {
+  = name:(Identifier / ReturnOpCode) __ '(' __ head:AssemblyItem? __ tail:( ',' __ AssemblyItem )* __ ')' {
     return {
       type: "FunctionalAssemblyInstruction",
       name: name,

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -312,6 +312,19 @@ contract assemblyLocalBinding {
   }
 }
 
+contract assemblyReturn {
+  uint a = 10;
+
+  function get() constant returns(uint) {
+    assembly {
+        mstore(0x40, sload(0))
+        byte(0)
+        address(0)
+        return(0x40,32)
+    }
+  }
+}
+
 contract usesConst {
   uint const = 0;
 }


### PR DESCRIPTION
[List of opcodes in the Solidity docs](https://solidity.readthedocs.io/en/develop/assembly.html#opcodes): `return` looks like the only case that conflicts with the parser's keyword list. 

PR:
+ adds a rule to translate return tokens into Identifier nodes for `FunctionalAssemblyInstruction`. 
+ Adds an example to tests.

[Gist](https://gist.github.com/cgewecke/8989ee02fe56899b2441be008fa0f5b5) of AST output with this change. 

Resolves #81 


