### PR TITLE
Parse "returns" in FunctionDeclaration

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -1372,7 +1372,7 @@ FunctionDeclaration
         name: fnname.name,
         params: fnname.params,
         modifiers: args,
-        returns: returns,
+        returnParams: returns,
         body: body,
         is_abstract: false,
         start: location().start.offset,

--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -220,6 +220,7 @@ Keyword
   / NewToken
   / PragmaToken
   / ReturnToken
+  / ReturnsToken
   / ThisToken
   / ThrowToken
   / VarToken
@@ -1364,32 +1365,40 @@ ModifierDeclaration
     }
 
 FunctionDeclaration
-  = FunctionToken __ fnname:FunctionName __ args:ModifierArgumentList? __ body:FunctionBody
+  = FunctionToken __ fnname:FunctionName __ args:ModifierArgumentList? __ returns:ReturnsDeclaration? __ body:FunctionBody
     {
       return {
         type: "FunctionDeclaration",
         name: fnname.name,
         params: fnname.params,
         modifiers: args,
+        returns: returns,
         body: body,
         is_abstract: false,
         start: location().start.offset,
         end: location().end.offset
       };
     }
-  / FunctionToken __ fnname:FunctionName __ args:ModifierArgumentList? __ EOS
+  / FunctionToken __ fnname:FunctionName __ args:ModifierArgumentList? __ returns:ReturnsDeclaration? __ EOS
     {
       return {
         type: "FunctionDeclaration",
         name: fnname.name,
         params: fnname.params,
         modifiers: args,
+        returns: returns,
         body: null,
         is_abstract: true,
         start: location().start.offset,
         end: location().end.offset
       };
     }
+
+ReturnsDeclaration
+  = ReturnsToken __ params:("(" __ InformalParameterList __ ")")
+  {
+    return params != null ? params [2] : null;
+  }
     
 
 FunctionName

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -396,6 +396,9 @@ contract Ballot {
       return false;
     }
 
+    function foobar() payable owner (myPrice) returns (uint[], address myAdd, string[] names) {}
+    function foobar() payable owner (myPrice) returns (uint[], address myAdd, string[] names);
+
     Voter you = Voter(1, true);
 
     Voter me = Voter({


### PR DESCRIPTION
Fixes #80 

NOTE: ```returns``` cannot be without at least a single parameter.
```returns``` & ```returns ()``` throw errors (same behaviour as solc).
```returns (uint)```, etc get parsed fine.