### PR TITLE
Allow ReturnStatement arguments to be on subsequent lines

### DIFF
--- a/solidity.pegjs
+++ b/solidity.pegjs
@@ -1272,7 +1272,7 @@ ReturnStatement
   = ReturnToken EOS {
       return { type: "ReturnStatement", argument: null, start: location().start.offset, end: location().end.offset };
     }
-  / ReturnToken _ argument:Expression EOS {
+  / ReturnToken __ argument:Expression EOS {
       return { type: "ReturnStatement", argument: argument, start: location().start.offset, end: location().end.offset };
     }
 

--- a/test/doc_examples.sol
+++ b/test/doc_examples.sol
@@ -411,3 +411,10 @@ contract Ballot {
       voted: true,
     });
 }
+
+contract multilineReturn {
+  function a() returns (uint x) {
+    return
+      5;
+  }
+}


### PR DESCRIPTION
PR
+ uses the whitespace rule that consumes line-terminators for `ReturnStatements` with arguments.
+ adds an example to `doc_examples`

(I have a feeling this the tip of the iceberg for weird whitespace parsing issues here). 